### PR TITLE
pin k8s-ruby to 0.10.5

### DIFF
--- a/train-kubernetes.gemspec
+++ b/train-kubernetes.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
   # Do not list inspec as a dependency of the train plugin.
 
   # All plugins should mention train, > 1.4
-  spec.add_dependency 'k8s-ruby', '~> 0.10'
+  # pinning k8s-ruby to 0.10.5 to avoid broken dry-type gem upgrades from k8s-ruby
+  spec.add_dependency 'k8s-ruby', '0.10.5'
   spec.add_dependency 'train', '~> 3.0'
 end


### PR DESCRIPTION
Signed-off-by: Sathish <sbabu@progress.com>

<!--- Provide a short summary of your changes in the Title above -->
Downgrading k8s-ruby to 0.10.5, the most recent working version for train-kubernetes.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
k8s-ruby has an internal dependency on dry-types, for which the latest version has caused the train-kubernetes to break. So downgrading it to the most recent working version.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
