### PR TITLE
allow to update k8s-ruby to recent most version

### DIFF
--- a/train-kubernetes.gemspec
+++ b/train-kubernetes.gemspec
@@ -45,6 +45,6 @@ Gem::Specification.new do |spec|
 
   # All plugins should mention train, > 1.4
   # pinning k8s-ruby to 0.10.5 to avoid broken dry-type gem upgrades from k8s-ruby
-  spec.add_dependency 'k8s-ruby', '0.13.0'
+  spec.add_dependency 'k8s-ruby', '~> 0.14.0'
   spec.add_dependency 'train', '~> 3.0'
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Recently we upgraded k8s-ruby with support for 3.1 ruby. Hence extending that support to train-kubernetes as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
