### PR TITLE
CHEF-6185 Ruby 3.2.x support

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -17,15 +17,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.7
-
-- label: run-specs-ruby-2.7
-  command:
-    - /workdir/.expeditor/run_linux_tests.sh "rake spec"
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.7
+        image: ruby:3.0
 
 - label: run-specs-ruby-3.0
   command:
@@ -34,4 +26,20 @@ steps:
     executor:
       docker:
         image: ruby:3.0
+
+- label: run-specs-ruby-3.1
+  command:
+    - /workdir/.expeditor/run_linux_tests.sh "rake spec"
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.1
+
+- label: run-specs-ruby-3.2
+  command:
+    - /workdir/.expeditor/run_linux_tests.sh "rake spec"
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.2
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 Layout/ParameterAlignment:
   Enabled: true
 Style/BlockDelimiters:

--- a/train-kubernetes.gemspec
+++ b/train-kubernetes.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   # Do not list inspec as a dependency of the train plugin.
 
   # All plugins should mention train, > 1.4
-  # pinning k8s-ruby to 0.15.0 since it has support for Ruby version 3.2
-  spec.add_dependency 'k8s-ruby', '~> 0.15.0'
+  # pinning k8s-ruby to 0.15.1 since it has support for Ruby version 3.2
+  spec.add_dependency 'k8s-ruby', '~> 0.15.1'
   spec.add_dependency 'train', '~> 3.0'
 end

--- a/train-kubernetes.gemspec
+++ b/train-kubernetes.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   # Do not list inspec as a dependency of the train plugin.
 
   # All plugins should mention train, > 1.4
-  # pinning k8s-ruby to 0.15.1 since it has support for Ruby version 3.2
-  spec.add_dependency 'k8s-ruby', '~> 0.15.1'
+  # pinning k8s-ruby to 0.16.0 since it has support for Ruby version 3.2
+  spec.add_dependency 'k8s-ruby', '~> 0.16.0'
   spec.add_dependency 'train', '~> 3.0'
 end

--- a/train-kubernetes.gemspec
+++ b/train-kubernetes.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   # Do not list inspec as a dependency of the train plugin.
 
   # All plugins should mention train, > 1.4
-  # pinning k8s-ruby to 0.10.5 to avoid broken dry-type gem upgrades from k8s-ruby
-  spec.add_dependency 'k8s-ruby', '~> 0.14.0'
+  # pinning k8s-ruby to 0.15.0 since it has support for Ruby version 3.2
+  spec.add_dependency 'k8s-ruby', '~> 0.15.0'
   spec.add_dependency 'train', '~> 3.0'
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Ruby 3.2.x support:
1. Upgrade k8s-ruby to version 0.16.0 for ruby 3.2.x support
2. Drop CI tests for ruby 2.7 and add tests for ruby 3.1 and 3.2
3. Upgrade Rubocop to use ruby 3.0
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
