### PR TITLE
update resource pack link in README to inspec/inspec-k8s repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plugin allows applications that rely on Train to communicate with the Kuber
 
 ## Usage
 
-When used in combination with the [InSpec Kubernetes Resource Pack](https://github.com/bgeesaman/inspec-k8s) you can validate the spec of any Kubernetes resource you have access to:
+When used in combination with the [InSpec Kubernetes Resource Pack](https://github.com/inspec/inspec-k8s) you can validate the spec of any Kubernetes resource you have access to:
 
 ```ruby
 describe k8sobjects(api: 'v1', type: 'pods', namespace: 'default', labelSelector: 'run=nginx') do


### PR DESCRIPTION
## Description
Update the resource pack link in the README to use https://github.com/inspec/inspec-k8s which is a fork of the previous repo that is throwing a 404 error

## Related Issue
fixes #13 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
