### PR TITLE
Fixes version bump issue

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -6,7 +6,7 @@
 
 set -evx
 
-sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" lib/train-kubernetes/version.rb
+sed -i -r "s/VERSION = \".*\"/VERSION = \"$(cat VERSION)\"/" lib/train-kubernetes/version.rb
 
 # Once Expeditor finshes executing this script, it will commit the changes and push
 # the commit as a new tag corresponding to the value in the VERSION file.

--- a/lib/train-kubernetes/version.rb
+++ b/lib/train-kubernetes/version.rb
@@ -5,6 +5,6 @@
 
 module TrainPlugins
   module TrainKubernetes
-    VERSION = '0.1.12'.freeze
+    VERSION = "0.1.12".freeze
   end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This fixes the version bump issue.

Due to single quotes used in version.rb and the script to update version was not working version bumping was not happening. This changes will fix that issue.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
