### PR TITLE
CHEF-31151: enable Polaris integration

### DIFF
--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -171,7 +171,7 @@ jobs:
 
       # perform Blackduck software composition analysis (SCA) for 3rd party CVEs, licensing, and operational risk
       perform-blackduck-sca-scan: true
-          run-bundle-install: true # combined with generate sbom & generate github-sbom, also needs version above
+      run-bundle-install: true # combined with generate sbom & generate github-sbom, also needs version above
       blackduck-project-group-name: 'Chef-Agents' # typically one of (Chef), Chef-Agents, Chef-Automate, Chef-Chef360, Chef-Habitat, Chef-Infrastructure-Server, Chef-Shared-Services, Chef-Non-Product'
       blackduck-project-name: ${{ github.event.repository.name }} # BlackDuck project name, typically the repository name
       blackduck-force-low-accuracy-mode: true # if true, forces BlackDuck Detect to run in low accuracy mode which can reduce scan time for large projects at the cost of potentially missing some vulnerabilities; see https://synopsys.atlassian.net/wiki/spaces/INTDOCS/pages/1138617921/Black+Duck+Detect+Accuracy+Levels for details

--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -117,15 +117,15 @@ jobs:
  
       # BlackDuck SAST (Polaris) require a build or binary present in repo to do SAST testing
       # requires these secrets: POLARIS_SERVER_URL, POLARIS_ACCESS_TOKEN
-      perform-blackduck-polaris: false
+      perform-blackduck-polaris: true
       polaris-application-name: "Chef-Agents"  # one of these: Chef-Agents, Chef-Automate, Chef-Chef360, Chef-Habitat, Chef-Infrastructure-Server, Chef-Shared-Services, Chef-Other, Chef-Non-Product
       polaris-project-name: ${{ github.event.repository.name }}   # arch-sample-cli
-      polaris-working-directory: '.' # Working directory for the scan, defaults to . but usually lang-dependent like ./src
-      polaris-coverity-build-command: 'go build -o bin/chef-cli.exe' # Coverity build command, typically done in build stage by language or here as param 1-liner like "mvn clean install"
-      polaris-coverity-clean-command: 'go clean' # Coverity clean command, typically done before build stage by language or here as param 1-liner like "mvn clean"
-      polaris-detect-search-depth: '5' # Detect search depth, blank but can be set to "3" to search up to 3 levels of subdirectories for code to scan'
-      polaris-assessment-mode: 'SAST' # Assessment mode (SAST, CI or SOURCE_UPLOAD)
-      wait-for-scan: true
+      # polaris-working-directory: '.' # Working directory for the scan, defaults to . but usually lang-dependent like ./src
+      # polaris-coverity-build-command: 'go build -o bin/chef-cli.exe' # Coverity build command, typically done in build stage by language or here as param 1-liner like "mvn clean install"
+      # polaris-coverity-clean-command: 'go clean' # Coverity clean command, typically done before build stage by language or here as param 1-liner like "mvn clean"
+      # polaris-detect-search-depth: '5' # Detect search depth, blank but can be set to "3" to search up to 3 levels of subdirectories for code to scan'
+      # polaris-assessment-mode: 'SAST' # Assessment mode (SAST, CI or SOURCE_UPLOAD)
+      # wait-for-scan: true
       # polaris-detect-args: ''  # Additional Detect arguments, can supply extra arguments like "--detect.diagnostic=true"
       # coverity_build_command: "go build"
       # coverity_clean_command: "go clean"


### PR DESCRIPTION
Enabling `perform-blackduck-polaris: true` and commenting out Go-specific SAST config lines.

This work was completed with AI assistance following Progress AI policies.